### PR TITLE
Add Amiga desktop demo and link it across all OS demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A collection of interactive web-based operating system demos showcasing differen
 - **BeOS Demo**: [https://echooff3.github.io/glm-os-test/beos.html](https://echooff3.github.io/glm-os-test/beos.html)
 - **iPhone OS Demo**: [https://echooff3.github.io/glm-os-test/iphone.html](https://echooff3.github.io/glm-os-test/iphone.html)
 - **Android Marshmallow Demo**: [https://echooff3.github.io/glm-os-test/android.html](https://echooff3.github.io/glm-os-test/android.html)
+- **Amiga Desktop Demo**: [https://echooff3.github.io/glm-os-test/amiga.html](https://echooff3.github.io/glm-os-test/amiga.html)
 
 ## Features
 

--- a/amiga.html
+++ b/amiga.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Amiga Workbench Demo</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: "Topaz Plus", "Courier New", monospace;
+    background: #0055aa;
+    color: #fff;
+    overflow: hidden;
+    height: 100vh;
+}
+#menu-bar {
+    height: 30px;
+    background: linear-gradient(180deg, #d9d9d9 0%, #bdbdbd 100%);
+    border-bottom: 2px solid #8f8f8f;
+    color: #111;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 14px;
+    font-size: 14px;
+}
+#desktop {
+    position: relative;
+    height: calc(100vh - 30px);
+    background:
+      radial-gradient(circle at 20% 20%, rgba(255,255,255,.12) 0%, transparent 40%),
+      radial-gradient(circle at 80% 75%, rgba(255,255,255,.08) 0%, transparent 45%),
+      linear-gradient(135deg, #0055aa 0%, #003d7a 100%);
+}
+.icon-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 120px);
+    gap: 22px;
+    padding: 26px;
+}
+.desktop-icon {
+    text-decoration: none;
+    color: #fff;
+    text-align: center;
+    padding: 8px;
+    border-radius: 4px;
+    transition: background .15s ease;
+}
+.desktop-icon:hover { background: rgba(255,255,255,.18); }
+.icon {
+    width: 54px;
+    height: 54px;
+    margin: 0 auto 7px;
+    border: 2px solid #e7e7e7;
+    border-right-color: #6d6d6d;
+    border-bottom-color: #6d6d6d;
+    border-radius: 4px;
+    background: linear-gradient(180deg,#f7931e,#db6a0a);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    color: #fff;
+}
+.label {
+    font-size: 12px;
+    text-shadow: 1px 1px 0 rgba(0,0,0,.55);
+}
+#window {
+    position: absolute;
+    right: 40px;
+    top: 50px;
+    width: min(560px, calc(100vw - 90px));
+    background: #d5d5d5;
+    border: 2px solid #f2f2f2;
+    border-right-color: #737373;
+    border-bottom-color: #737373;
+    color: #111;
+}
+.window-title {
+    background: linear-gradient(180deg, #1f3f9f 0%, #14337f 100%);
+    color: #fff;
+    padding: 7px 10px;
+    font-size: 13px;
+    font-weight: bold;
+}
+.window-content {
+    padding: 14px;
+    line-height: 1.5;
+    font-size: 13px;
+}
+.window-content ul { margin-top: 8px; padding-left: 18px; }
+</style>
+</head>
+<body>
+<div id="menu-bar">
+    <div>🟧 Amiga Workbench 3.1 (Demo)</div>
+    <div id="clock"></div>
+</div>
+<div id="desktop">
+    <div class="icon-grid">
+        <a class="desktop-icon" href="index.html"><div class="icon">W</div><div class="label">Windows Demo</div></a>
+        <a class="desktop-icon" href="beos.html"><div class="icon">Be</div><div class="label">BeOS Demo</div></a>
+        <a class="desktop-icon" href="metro.html"><div class="icon">M</div><div class="label">Metro Demo</div></a>
+        <a class="desktop-icon" href="iphone.html"><div class="icon">i</div><div class="label">iPhone OS</div></a>
+        <a class="desktop-icon" href="android.html"><div class="icon">A</div><div class="label">Android</div></a>
+    </div>
+
+    <div id="window">
+        <div class="window-title">Welcome to the Amiga Desktop Demo</div>
+        <div class="window-content">
+            This retro desktop is inspired by classic Amiga Workbench styling.
+            <ul>
+                <li>Use the desktop icons to jump to any other OS demo.</li>
+                <li>All existing demos now include links back to this Amiga desktop.</li>
+                <li>Enjoy a quick nostalgia trip with modern browser interactions.</li>
+            </ul>
+        </div>
+    </div>
+</div>
+<script>
+function updateClock() {
+    const now = new Date();
+    document.getElementById('clock').textContent = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+setInterval(updateClock, 1000);
+updateClock();
+</script>
+</body>
+</html>

--- a/android.html
+++ b/android.html
@@ -1315,6 +1315,11 @@ function renderDemos(container) {
             '<div class="dl-icon" style="background:linear-gradient(135deg,#1a1a1a,#333)">i</div>' +
             '<span>iPhone OS Demo</span>' +
             '<span class="arrow">›</span>' +
+        '</a>' +
+        '<a href="amiga.html" class="demo-link">' +
+            '<div class="dl-icon" style="background:linear-gradient(135deg,#f7931e,#ffb347)">Am</div>' +
+            '<span>Amiga Desktop Demo</span>' +
+            '<span class="arrow">›</span>' +
         '</a>';
 }
 </script>

--- a/beos.html
+++ b/beos.html
@@ -84,6 +84,10 @@
             background: linear-gradient(180deg, #1a1a1a 0%, #333 100%);
         }
 
+        .desktop-icon.os-link.amiga .icon {
+            background: linear-gradient(180deg, #ff6b35 0%, #f7931e 100%);
+        }
+
         .desktop-icon.os-link:hover {
             background: rgba(255, 255, 255, 0.5);
             transform: scale(1.05);
@@ -1742,6 +1746,11 @@
                         <circle fill="#fff" cx="28" cy="18" r="1.5"/>
                         <line x1="18" y1="10" x2="16" y2="6" stroke="#a4c639" stroke-width="1.5" stroke-linecap="round"/>
                         <line x1="30" y1="10" x2="32" y2="6" stroke="#a4c639" stroke-width="1.5" stroke-linecap="round"/>
+                    </svg>`,
+                    amiga: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" style="width:32px;height:32px;">
+                        <rect fill="#f7931e" width="48" height="48" rx="8"/>
+                        <path fill="#fff" d="M12 34l8-20h8l8 20h-5l-2-5H19l-2 5zm9-9h6l-3-8z"/>
+                        <rect fill="#2d2d2d" x="10" y="36" width="28" height="3" rx="1.5"/>
                     </svg>`
                 };
 
@@ -1777,6 +1786,14 @@
                         className: 'android',
                         x: window.innerWidth - ICON_OFFSET_FROM_RIGHT,
                         y: 320
+                    },
+                    {
+                        name: 'Amiga Desktop',
+                        url: 'amiga.html',
+                        icon: OS_ICONS.amiga,
+                        className: 'amiga',
+                        x: window.innerWidth - ICON_OFFSET_FROM_RIGHT,
+                        y: 420
                     }
                 ];
 

--- a/index.html
+++ b/index.html
@@ -82,6 +82,10 @@
             background: linear-gradient(135deg, #1a1a1a 0%, #333 100%);
         }
 
+        .desktop-icon.os-link.amiga .icon {
+            background: linear-gradient(135deg, #ff6b35 0%, #f7931e 100%);
+        }
+
         .desktop-icon.os-link:hover {
             background: rgba(255, 255, 255, 0.3);
             transform: scale(1.05);
@@ -1759,6 +1763,11 @@
                         <circle fill="#fff" cx="28" cy="18" r="1.5"/>
                         <line x1="18" y1="10" x2="16" y2="6" stroke="#a4c639" stroke-width="1.5" stroke-linecap="round"/>
                         <line x1="30" y1="10" x2="32" y2="6" stroke="#a4c639" stroke-width="1.5" stroke-linecap="round"/>
+                    </svg>`,
+                    amiga: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" style="width:32px;height:32px;">
+                        <rect fill="#f7931e" width="48" height="48" rx="8"/>
+                        <path fill="#fff" d="M12 34l8-20h8l8 20h-5l-2-5H19l-2 5zm9-9h6l-3-8z"/>
+                        <rect fill="#2d2d2d" x="10" y="36" width="28" height="3" rx="1.5"/>
                     </svg>`
                 };
 
@@ -1794,6 +1803,14 @@
                         className: 'android',
                         x: window.innerWidth - ICON_OFFSET_FROM_RIGHT,
                         y: 320
+                    },
+                    {
+                        name: 'Amiga Desktop',
+                        url: 'amiga.html',
+                        icon: OS_ICONS.amiga,
+                        className: 'amiga',
+                        x: window.innerWidth - ICON_OFFSET_FROM_RIGHT,
+                        y: 420
                     }
                 ];
 

--- a/iphone.html
+++ b/iphone.html
@@ -1426,6 +1426,11 @@ function renderDemos(container) {
                 '<span>Android Marshmallow Demo</span>' +
                 '<span class="arrow">›</span>' +
             '</a>' +
+            '<a href="amiga.html" class="demo-link">' +
+                '<div class="dl-icon" style="background:linear-gradient(135deg,#f7931e,#ffb347)">Am</div>' +
+                '<span>Amiga Desktop Demo</span>' +
+                '<span class="arrow">›</span>' +
+            '</a>' +
         '</div>';
 }
 </script>

--- a/metro.html
+++ b/metro.html
@@ -1173,6 +1173,18 @@
                 </div>
                 <div class="tile-label">Android Demo</div>
             </div>
+
+            <!-- Amiga Desktop Demo Tile -->
+            <div class="tile tile-wide os-demo-tile" style="background:linear-gradient(135deg,#f7931e,#ffb347)" onclick="window.location.href='amiga.html'" data-search="amiga demo">
+                <div class="tile-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" style="width:48px;height:48px;">
+                        <rect fill="#f7931e" width="48" height="48" rx="8"/>
+                        <path fill="#fff" d="M12 34l8-20h8l8 20h-5l-2-5H19l-2 5zm9-9h6l-3-8z"/>
+                        <rect fill="#2d2d2d" x="10" y="36" width="28" height="3" rx="1.5"/>
+                    </svg>
+                </div>
+                <div class="tile-label">Amiga Desktop</div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Introduce an Amiga Workbench-style demo to the collection and ensure it is discoverable from all existing OS demos for seamless navigation across the site.
- Provide a lightweight, browser-friendly Amiga-themed page that links back to the existing demos and receives reciprocal links from them.

### Description
- Added a new `amiga.html` demo page implementing an Amiga Workbench-inspired desktop with a small info window, a live clock, and desktop icons linking to `index.html`, `beos.html`, `metro.html`, `iphone.html`, and `android.html`.
- Added Amiga styling, SVG icon and an `Amiga Desktop` entry to the `osLinks` navigation icons in `index.html` and `beos.html` so those desktops show a clickable Amiga icon.
- Added an `Amiga Desktop` tile to Metro's "Try Other OS Demos" area in `metro.html` so Metro links to the new demo.
- Added `Amiga Desktop Demo` entries to the OS Demos lists in `iphone.html` and `android.html`, and updated `README.md` to include the new demo URL.
- Committed the changes and created the PR (changes include `amiga.html`, updates to `index.html`, `beos.html`, `metro.html`, `iphone.html`, `android.html`, and `README.md`).

### Testing
- Verified references and wiring with `rg -n "amiga|Amiga" index.html beos.html metro.html iphone.html android.html README.md amiga.html` and confirmed the new links were present.
- Confirmed repository changes and size with `git diff --stat` and `git status --short` which showed the expected files modified and `amiga.html` added.
- Confirmed commit was created and inspected current HEAD with `git rev-parse --short HEAD` (commit `ba3d081`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c177ffab9c8320838b3fc2f6c09e45)